### PR TITLE
Adding docker packaging

### DIFF
--- a/ProjetGL/Dockerfile
+++ b/ProjetGL/Dockerfile
@@ -1,0 +1,6 @@
+FROM vibioh/java
+
+VOLUME /tmp
+ENTRYPOINT [ "java", "-jar", "/app.jar"]
+COPY target/*.jar /app.jar
+

--- a/ProjetGL/docker-compose.yml
+++ b/ProjetGL/docker-compose.yml
@@ -1,25 +1,6 @@
 version: '2'
 
 services:
-  spring:
-    image: annonce
-    command: -Xmx512M -XX:MaxPermSize=384M -XX:+CMSClassUnloadingEnabled --spring.datasource.url=jdbc:mysql://db:3306/annonce
-    labels:
-      traefik.frontend.passHostHeader: 'true'
-      traefik.frontend.rule: 'Host: annonce.l3miage.fr'
-      traefik.port: '8088'
-    links:
-    - db
-    logging:
-      driver: json-file
-      options:
-        max-size: '50m'
-    restart: on-failure:5
-    read_only: true
-    cpu_shares: 128
-    security_opt:
-    - no-new-privileges
-
   db:
     image: vibioh/mysql
     environment:
@@ -33,6 +14,26 @@ services:
     read_only: true
     cpu_shares: 128
     mem_limit: 134217728
+    security_opt:
+    - no-new-privileges
+
+  spring:
+    image: vibioh/annonce
+    command: --spring.datasource.url=jdbc:mysql://db:3306/annonce
+    labels:
+      traefik.frontend.passHostHeader: 'true'
+      traefik.frontend.rule: 'Host: annonce.l3miage.fr'
+      traefik.port: '8088'
+    links:
+    - db
+    logging:
+      driver: json-file
+      options:
+        max-size: '50m'
+    restart: on-failure:5
+    read_only: true
+    cpu_shares: 128
+    mem_limit: 805306368
     security_opt:
     - no-new-privileges
 

--- a/ProjetGL/docker-compose.yml
+++ b/ProjetGL/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+
+services:
+  spring:
+    image: annonce
+    command: -Xmx512M -XX:MaxPermSize=384M -XX:+CMSClassUnloadingEnabled --spring.datasource.url=jdbc:mysql://db:3306/annonce
+    labels:
+      traefik.frontend.passHostHeader: 'true'
+      traefik.frontend.rule: 'Host: annonce.l3miage.fr'
+      traefik.port: '8088'
+    links:
+    - db
+    logging:
+      driver: json-file
+      options:
+        max-size: '50m'
+    restart: on-failure:5
+    cpu_shares: 128
+    security_opt:
+    - no-new-privileges
+
+  db:
+    image: vibioh/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: 'root'
+      MYSQL_DATABASE: 'annonce'
+    logging:
+      driver: json-file
+      options:
+        max-size: '50m'
+    restart: on-failure:5
+    read_only: true
+    cpu_shares: 128
+    mem_limit: 134217728
+    security_opt:
+    - no-new-privileges
+
+networks:
+  default:
+    external:
+      name: traefik
+

--- a/ProjetGL/docker-compose.yml
+++ b/ProjetGL/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       options:
         max-size: '50m'
     restart: on-failure:5
+    read_only: true
     cpu_shares: 128
     security_opt:
     - no-new-privileges

--- a/ProjetGL/docker-compose.yml
+++ b/ProjetGL/docker-compose.yml
@@ -19,7 +19,8 @@ services:
 
   spring:
     image: vibioh/annonce
-    command: --spring.datasource.url=jdbc:mysql://db:3306/annonce
+    command:
+    - --spring.datasource.url=jdbc:mysql://db:3306/annonce
     labels:
       traefik.frontend.passHostHeader: 'true'
       traefik.frontend.rule: 'Host: annonce.l3miage.fr'


### PR DESCRIPTION
Pour construire l'image localement

```
cd ProjetGL
docker build -t annonce .
```

Pour le lancement

```
docker-compose up -d
```

Au premier lancement, la base de données sera créée. La configuration est ciblée pour l'environnement de déploiement (en local vous ne verrez pas grand chose).

Si vous souhaitez changer le nom de domaine, merci de me le communiquer au préalable, que je mette à jour le DNS.

Je vais faire la documentation pour utiliser le déploiement prochainement !